### PR TITLE
`--matching` compression option, and Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+o/
+z64compress

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+bin/
 o/
 z64compress

--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,40 @@
 CC := gcc
 CFLAGS := -DNDEBUG -s -Os -flto -Wall -Wextra
 
-o/src/enc/%.o: CFLAGS := -DNDEBUG -s -Ofast -flto -Wall
+OBJ_DIR := o
+
+# Target platform, specify with TARGET= on the command line, linux64 is default
+# Currently supported: linux64, linux32, win32
+TARGET ?= linux64
+
+ifeq ($(TARGET),linux32)
+	TARGET_CFLAGS := -m32
+else ifeq ($(TARGET),win32)
+# If using a cross compiler, specify the compiler executable on the command line
+# make TARGET=win32 CC=~/c/mxe/usr/bin/i686-w64-mingw32.static-gcc
+	TARGET_LIBS := -mconsole -municode
+else ifneq ($(TARGET),linux64)
+	$(error Supported targets: linux64, linux32, win32)
+endif
+
+OBJ_DIR := $(OBJ_DIR)/$(TARGET)
+
+$(OBJ_DIR)/src/enc/%.o: CFLAGS := -DNDEBUG -s -Ofast -flto -Wall
 
 SRC_DIRS := $(shell find src -type d)
 C_FILES  := $(foreach dir,$(SRC_DIRS),$(wildcard $(dir)/*.c))
-O_FILES  := $(foreach f,$(C_FILES:.c=.o),o/$f)
+O_FILES  := $(foreach f,$(C_FILES:.c=.o),$(OBJ_DIR)/$f)
 
-$(shell mkdir -p $(foreach dir,$(SRC_DIRS),o/$(dir)))
+# Make build directories
+$(shell mkdir -p $(foreach dir,$(SRC_DIRS),$(OBJ_DIR)/$(dir)))
+
+.PHONY: all clean
 
 all: $(O_FILES)
-	$(CC) $(CFLAGS) $(O_FILES) -lm -lpthread -o z64compress
+	$(CC) $(TARGET_CFLAGS) $(CFLAGS) $(O_FILES) -lm -lpthread $(TARGET_LIBS) -o z64compress
 
-o/%.o: %.c
-	$(CC) -c $(CFLAGS) $< -o $@
+$(OBJ_DIR)/%.o: %.c
+	$(CC) -c $(TARGET_CFLAGS) $(CFLAGS) $< -o $@
 
 clean:
-	$(RM) -rf z64compress o
+	$(RM) -rf z64compress bin o

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+CC := gcc
+CFLAGS := -DNDEBUG -s -Os -flto -Wall -Wextra
+
+o/src/enc/%.o: CFLAGS := -DNDEBUG -s -Ofast -flto -Wall
+
+SRC_DIRS := $(shell find src -type d)
+C_FILES  := $(foreach dir,$(SRC_DIRS),$(wildcard $(dir)/*.c))
+O_FILES  := $(foreach f,$(C_FILES:.c=.o),o/$f)
+
+$(shell mkdir -p $(foreach dir,$(SRC_DIRS),o/$(dir)))
+
+all: $(O_FILES)
+	$(CC) $(CFLAGS) $(O_FILES) -lm -lpthread -o z64compress
+
+o/%.o: %.c
+	$(CC) -c $(CFLAGS) $< -o $@
+
+clean:
+	$(RM) -rf z64compress o

--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ This is a command line application. Learn from these common examples and adapt t
 
     --out       compressed output rom
 
+    --matching  attempt matching compression at the cost of
+	              some optimizations and reduced performance
+
     --mb        how many mb the compressed rom should be
 
     --codec     currently supported codecs
@@ -83,3 +86,4 @@ This is a command line application. Learn from these common examples and adapt t
 ## Building
 I have included shell scripts for building Linux and Windows binaries. Windows binaries are built using a cross compiler ([I recommend `MXE`](https://mxe.cc/)).
 
+Alternatively, a Makefile-based build system is provided. Choose the target platform with `make TARGET=linux64|linux32|win32`, default is linux64. If building for windows with a cross compiler, specify the compiler executable with `make TARGET=win32 CC=/path/to/executable`.

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ This is a command line application. Learn from these common examples and adapt t
     --out       compressed output rom
 
     --matching  attempt matching compression at the cost of
-	              some optimizations and reduced performance
+                some optimizations and reduced performance
 
     --mb        how many mb the compressed rom should be
 

--- a/src/main.c
+++ b/src/main.c
@@ -157,7 +157,7 @@ static void usage(void)
 	fprintf(stderr, "    --out       compressed output rom\n");
 	fprintf(stderr, "\n");
 	fprintf(stderr, "    --matching  attempt matching compression at the cost of\n");
-	fprintf(stderr, "                optimizations and some performance drops\n");
+	fprintf(stderr, "                some optimizations and reduced performance\n");
 	fprintf(stderr, "\n");
 	fprintf(stderr, "    --mb        how many mb the compressed rom should be\n");
 	fprintf(stderr, "\n");

--- a/src/main.c
+++ b/src/main.c
@@ -1,4 +1,5 @@
 #include <ctype.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -155,6 +156,9 @@ static void usage(void)
 	fprintf(stderr, "\n");
 	fprintf(stderr, "    --out       compressed output rom\n");
 	fprintf(stderr, "\n");
+	fprintf(stderr, "    --matching  attempt matching compression at the cost of\n");
+	fprintf(stderr, "                optimizations and some performance drops\n");
+	fprintf(stderr, "\n");
 	fprintf(stderr, "    --mb        how many mb the compressed rom should be\n");
 	fprintf(stderr, "\n");
 	fprintf(stderr, "    --codec     currently supported codecs\n");
@@ -196,6 +200,7 @@ wow_main
 	const char *Adma = 0;
 	const char *Acodec = 0;
 	const char *Acache = 0;
+	bool Amatching = false;
 	int Amb = 0;
 	int Athreads = 0;
 	wow_main_argv;
@@ -230,6 +235,13 @@ wow_main
 				die("--out arg provided more than once");
 			Aout = next;
 		}
+		else if (!strcmp(arg, "--matching"))
+		{
+			if (Amatching)
+				die("--matching arg provided more than once");
+			Amatching = true;
+			i--; // hack, this option has no arguments
+		}
 		else if (!strcmp(arg, "--cache"))
 		{
 			if (Acache)
@@ -260,7 +272,7 @@ wow_main
 			Adma = next;
 			if (sscanf(Adma, "%i,%i", &start, &num) != 2)
 				die("--dma bad formatting '%s'", Adma);
-			rom_dma(rom, start, num);
+			rom_dma(rom, start, num, Amatching);
 		}
 		else if (!strcmp(arg, "--mb"))
 		{
@@ -318,10 +330,10 @@ wow_main
 	#undef ARG_ZERO_TEST
 	
 	/* finished initializing dma settings */
-	rom_dma_ready(rom);
+	rom_dma_ready(rom, Amatching);
 	
 	/* compress rom */
-	rom_compress(rom, Amb, Athreads);
+	rom_compress(rom, Amb, Athreads, Amatching);
 	fprintf(stderr, "rom compressed successfully!\n");
 	
 	/* write compressed rom */

--- a/src/rom.h
+++ b/src/rom.h
@@ -23,13 +23,13 @@ void rom_free(struct rom *rom);
 void rom_save(struct rom *rom, const char *fn);
 
 /* compress rom using specified algorithm */
-void rom_compress(struct rom *rom, int mb, int numThreads);
+void rom_compress(struct rom *rom, int mb, int numThreads, bool matching);
 
 /* specify start of dmadata and number of entries */
-void rom_dma(struct rom *rom, unsigned int offset, int num_entries);
+void rom_dma(struct rom *rom, unsigned int offset, int num_entries, bool matching);
 
 /* call this once dma settings are finalized */
-void rom_dma_ready(struct rom *rom);
+void rom_dma_ready(struct rom *rom, bool matching);
 
 /* set compression flag on indices start <= idx <= end */
 void


### PR DESCRIPTION
Adds an option that will compress a rom without certain optimizations in such a way that, if compressing the same unmodified files, will match an original compressed rom.
Most notably, this option changes how deleted files in dmadata are handled. It preserves them instead of moving them.
This option also changes how the rom is padded, original retail roms are padded to their final size with `00010203....FF00010203....` so this behavior is also copied.

Also adds a `.gitignore` to exclude compiled objects and binaries and a `Makefile` for easy integration into projects using a Makefile-based build system such as projects based on the decompilation projects.
