### PR TITLE
`--only-stdout` flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,9 @@ $(shell mkdir -p $(foreach dir,$(SRC_DIRS),$(OBJ_DIR)/$(dir)))
 
 .PHONY: all clean
 
-all: $(O_FILES)
+all: z64compress
+
+z64compress: $(O_FILES)
 	$(CC) $(TARGET_CFLAGS) $(CFLAGS) $(O_FILES) -lm -lpthread $(TARGET_LIBS) -o z64compress
 
 $(OBJ_DIR)/%.o: %.c

--- a/README.md
+++ b/README.md
@@ -10,74 +10,77 @@ If you add an algorithm, please make sure `valgrind` reports no memory leaks or 
 This is a command line application. Learn from these common examples and adapt the arguments to your needs:
 ```
   compressing oot debug
-    --in        "path/to/in.z64"
-    --out       "path/to/out.z64"
-    --mb        32
-    --codec     yaz
-    --cache     "path/to/cache"
-    --dma       "0x12F70,1548"
-    --compress  "9-14,28-END"
-    --threads   4
+    --in           "path/to/in.z64"
+    --out          "path/to/out.z64"
+    --mb           32
+    --codec        yaz
+    --cache        "path/to/cache"
+    --dma          "0x12F70,1548"
+    --compress     "9-14,28-END"
+    --threads      4
 
   compressing oot ntsc 1.0
-    --in        "path/to/in.z64"
-    --out       "path/to/out.z64"
-    --mb        32
-    --codec     yaz
-    --cache     "path/to/cache"
-    --dma       "0x7430,1526"
-    --compress  "10-14,27-END"
-    --threads   4
+    --in           "path/to/in.z64"
+    --out          "path/to/out.z64"
+    --mb           32
+    --codec        yaz
+    --cache        "path/to/cache"
+    --dma          "0x7430,1526"
+    --compress     "10-14,27-END"
+    --threads      4
 
   compressing mm usa
-    --in        "path/to/in.z64"
-    --out       "path/to/out.z64"
-    --mb        32
-    --codec     yaz
-    --cache     "path/to/cache"
-    --dma       "0x1A500,1568"
-    --compress  "10-14,23,24,31-END"
-    --skip      "1127"
-    --repack    "15-20,22"
-    --threads   4
+    --in           "path/to/in.z64"
+    --out          "path/to/out.z64"
+    --mb           32
+    --codec        yaz
+    --cache        "path/to/cache"
+    --dma          "0x1A500,1568"
+    --compress     "10-14,23,24,31-END"
+    --skip         "1127"
+    --repack       "15-20,22"
+    --threads      4
 ```
 
 ## Arguments
 ```
-    --in        uncompressed input rom
+    --in           uncompressed input rom
 
-    --out       compressed output rom
+    --out          compressed output rom
 
-    --matching  attempt matching compression at the cost of
-                some optimizations and reduced performance
+    --matching     attempt matching compression at the cost of
+                   some optimizations and reduced performance
 
-    --mb        how many mb the compressed rom should be
+    --mb           how many mb the compressed rom should be
 
-    --codec     currently supported codecs
-                   yaz
-                   ucl
-                   lzo
-                   aplib
-              * to use non-yaz codecs, find patches
-                and code on my z64enc repo
+    --codec        currently supported codecs
+                      yaz
+                      ucl
+                      lzo
+                      aplib
+                 * to use non-yaz codecs, find patches
+                   and code on my z64enc repo
 
-    --cache     is optional and won't be created if
-                no path is specified (having a cache
-                makes subsequent compressions faster)
-              * pro-tip: linux users who don't want a
-                cache to persist across power cycles
-                can use the path "/tmp/z64compress"
+    --cache        is optional and won't be created if
+                   no path is specified (having a cache
+                   makes subsequent compressions faster)
+                 * pro-tip: linux users who don't want a
+                   cache to persist across power cycles
+                   can use the path "/tmp/z64compress"
 
-    --dma       specify dmadata address and count
+    --dma          specify dmadata address and count
 
-    --compress  enable compression on specified files
+    --compress     enable compression on specified files
 
-    --skip      disable compression on specified files
+    --skip         disable compression on specified files
 
-    --repack    handles Majora's Mask archives
+    --repack       handles Majora's Mask archives
 
-    --threads   optional multithreading;
-                exclude this argument to disable it
+    --threads      optional multithreading;
+                   exclude this argument to disable it
+
+    --only-stdout  reserve stderr for errors and print
+                   everything else to stdout
 
   arguments are executed as they
   are parsed, so order matters!

--- a/src/main.c
+++ b/src/main.c
@@ -7,6 +7,8 @@
 #include "wow.h"
 #include "rom.h"
 
+FILE* printer;
+
 static void compress(struct rom *rom, int start, int end)
 {
 	rom_dma_compress(rom, start, end, 1);
@@ -118,78 +120,80 @@ static void do_pattern(
 static void usage(void)
 {
 	/* compression examples for users to adapt to their needs */
-	fprintf(stderr, "\n");
-	fprintf(stderr, "  compressing oot debug\n");
-	fprintf(stderr, "    --in        \"path/to/in.z64\"\n");
-	fprintf(stderr, "    --out       \"path/to/out.z64\"\n");
-	fprintf(stderr, "    --mb        32\n");
-	fprintf(stderr, "    --codec     yaz\n");
-	fprintf(stderr, "    --cache     \"path/to/cache\"\n");
-	fprintf(stderr, "    --dma       \"0x12F70,1548\"\n");
-	fprintf(stderr, "    --compress  \"9-14,28-END\"\n");
-	fprintf(stderr, "    --threads   4\n");
-	fprintf(stderr, "\n");
-	fprintf(stderr, "  compressing oot ntsc 1.0\n");
-	fprintf(stderr, "    --in        \"path/to/in.z64\"\n");
-	fprintf(stderr, "    --out       \"path/to/out.z64\"\n");
-	fprintf(stderr, "    --mb        32\n");
-	fprintf(stderr, "    --codec     yaz\n");
-	fprintf(stderr, "    --cache     \"path/to/cache\"\n");
-	fprintf(stderr, "    --dma       \"0x7430,1526\"\n");
-	fprintf(stderr, "    --compress  \"10-14,27-END\"\n");
-	fprintf(stderr, "    --threads   4\n");
-	fprintf(stderr, "\n");
-	fprintf(stderr, "  compressing mm usa\n");
-	fprintf(stderr, "    --in        \"path/to/in.z64\"\n");
-	fprintf(stderr, "    --out       \"path/to/out.z64\"\n");
-	fprintf(stderr, "    --mb        32\n");
-	fprintf(stderr, "    --codec     yaz\n");
-	fprintf(stderr, "    --cache     \"path/to/cache\"\n");
-	fprintf(stderr, "    --dma       \"0x1A500,1568\"\n");
-	fprintf(stderr, "    --compress  \"10-14,23,24,31-END\"\n");
-	fprintf(stderr, "    --skip      \"1127\"\n");
-	fprintf(stderr, "    --repack    \"15-20,22\"\n");
-	fprintf(stderr, "    --threads   4\n");
-	fprintf(stderr, "\n");
-	fprintf(stderr, "  arguments\n");
-	fprintf(stderr, "    --in        uncompressed input rom\n");
-	fprintf(stderr, "\n");
-	fprintf(stderr, "    --out       compressed output rom\n");
-	fprintf(stderr, "\n");
-	fprintf(stderr, "    --matching  attempt matching compression at the cost of\n");
-	fprintf(stderr, "                some optimizations and reduced performance\n");
-	fprintf(stderr, "\n");
-	fprintf(stderr, "    --mb        how many mb the compressed rom should be\n");
-	fprintf(stderr, "\n");
-	fprintf(stderr, "    --codec     currently supported codecs\n");
-	fprintf(stderr, "                   yaz\n");
-	fprintf(stderr, "                   ucl\n");
-	fprintf(stderr, "                   lzo\n");
-	fprintf(stderr, "                   aplib\n");
-	fprintf(stderr, "              * to use non-yaz codecs, find patches\n");
-	fprintf(stderr, "                and code on my z64enc repo\n");
-	fprintf(stderr, "\n");
-	fprintf(stderr, "    --cache     is optional and won't be created if\n");
-	fprintf(stderr, "                no path is specified (having a cache\n");
-	fprintf(stderr, "                makes subsequent compressions faster)\n");
-	fprintf(stderr, "              * pro-tip: linux users who don't want a\n");
-	fprintf(stderr, "                cache to persist across power cycles\n");
-	fprintf(stderr, "                can use the path \"/tmp/z64compress\"\n");
-	fprintf(stderr, "\n");
-	fprintf(stderr, "    --dma       specify dmadata address and count\n");
-	fprintf(stderr, "\n");
-	fprintf(stderr, "    --compress  enable compression on specified files\n");
-	fprintf(stderr, "\n");
-	fprintf(stderr, "    --skip      disable compression on specified files\n");
-	fprintf(stderr, "\n");
-	fprintf(stderr, "    --repack    handles Majora's Mask archives\n");
-	fprintf(stderr, "\n");
-	fprintf(stderr, "    --threads   optional multithreading;\n");
-	fprintf(stderr, "                exclude this argument to disable it\n");
-	fprintf(stderr, "\n");
-	fprintf(stderr, "  arguments are executed as they\n");
-	fprintf(stderr, "  are parsed, so order matters!\n");
-	fprintf(stderr, "\n");
+	fprintf(printer, "\n");
+	fprintf(printer, "  compressing oot debug\n");
+	fprintf(printer, "    --in           \"path/to/in.z64\"\n");
+	fprintf(printer, "    --out          \"path/to/out.z64\"\n");
+	fprintf(printer, "    --mb           32\n");
+	fprintf(printer, "    --codec        yaz\n");
+	fprintf(printer, "    --cache        \"path/to/cache\"\n");
+	fprintf(printer, "    --dma          \"0x12F70,1548\"\n");
+	fprintf(printer, "    --compress     \"9-14,28-END\"\n");
+	fprintf(printer, "    --threads      4\n");
+	fprintf(printer, "\n");
+	fprintf(printer, "  compressing oot ntsc 1.0\n");
+	fprintf(printer, "    --in           \"path/to/in.z64\"\n");
+	fprintf(printer, "    --out          \"path/to/out.z64\"\n");
+	fprintf(printer, "    --mb           32\n");
+	fprintf(printer, "    --codec        yaz\n");
+	fprintf(printer, "    --cache        \"path/to/cache\"\n");
+	fprintf(printer, "    --dma          \"0x7430,1526\"\n");
+	fprintf(printer, "    --compress     \"10-14,27-END\"\n");
+	fprintf(printer, "    --threads      4\n");
+	fprintf(printer, "\n");
+	fprintf(printer, "  compressing mm usa\n");
+	fprintf(printer, "    --in           \"path/to/in.z64\"\n");
+	fprintf(printer, "    --out          \"path/to/out.z64\"\n");
+	fprintf(printer, "    --mb           32\n");
+	fprintf(printer, "    --codec        yaz\n");
+	fprintf(printer, "    --cache        \"path/to/cache\"\n");
+	fprintf(printer, "    --dma          \"0x1A500,1568\"\n");
+	fprintf(printer, "    --compress     \"10-14,23,24,31-END\"\n");
+	fprintf(printer, "    --skip         \"1127\"\n");
+	fprintf(printer, "    --repack       \"15-20,22\"\n");
+	fprintf(printer, "    --threads      4\n");
+	fprintf(printer, "\n");
+	fprintf(printer, "  arguments\n");
+	fprintf(printer, "    --in           uncompressed input rom\n");
+	fprintf(printer, "\n");
+	fprintf(printer, "    --out          compressed output rom\n");
+	fprintf(printer, "\n");
+	fprintf(printer, "    --matching     attempt matching compression at the cost of\n");
+	fprintf(printer, "                   some optimizations and reduced performance\n");
+	fprintf(printer, "\n");
+	fprintf(printer, "    --mb           how many mb the compressed rom should be\n");
+	fprintf(printer, "\n");
+	fprintf(printer, "    --codec        currently supported codecs\n");
+	fprintf(printer, "                      yaz\n");
+	fprintf(printer, "                      ucl\n");
+	fprintf(printer, "                      lzo\n");
+	fprintf(printer, "                      aplib\n");
+	fprintf(printer, "                 * to use non-yaz codecs, find patches\n");
+	fprintf(printer, "                   and code on my z64enc repo\n");
+	fprintf(printer, "\n");
+	fprintf(printer, "    --cache        is optional and won't be created if\n");
+	fprintf(printer, "                   no path is specified (having a cache\n");
+	fprintf(printer, "                   makes subsequent compressions faster)\n");
+	fprintf(printer, "                 * pro-tip: linux users who don't want a\n");
+	fprintf(printer, "                   cache to persist across power cycles\n");
+	fprintf(printer, "                   can use the path \"/tmp/z64compress\"\n");
+	fprintf(printer, "\n");
+	fprintf(printer, "    --dma          specify dmadata address and count\n");
+	fprintf(printer, "\n");
+	fprintf(printer, "    --compress     enable compression on specified files\n");
+	fprintf(printer, "\n");
+	fprintf(printer, "    --skip         disable compression on specified files\n");
+	fprintf(printer, "\n");
+	fprintf(printer, "    --repack       handles Majora's Mask archives\n");
+	fprintf(printer, "\n");
+	fprintf(printer, "    --threads      optional multithreading;\n");
+	fprintf(printer, "                   exclude this argument to disable it\n");
+	fprintf(printer, "\n");
+	fprintf(printer, "    --only-stdout  reserve printer for true errors\n");
+	fprintf(printer, "\n");
+	fprintf(printer, "  arguments are executed as they\n");
+	fprintf(printer, "  are parsed, so order matters!\n");
+	fprintf(printer, "\n");
 }
 
 wow_main
@@ -200,12 +204,23 @@ wow_main
 	const char *Adma = 0;
 	const char *Acodec = 0;
 	const char *Acache = 0;
-	bool Amatching = false;
 	int Amb = 0;
 	int Athreads = 0;
+	bool Amatching = false;
+	bool Aonly_stdout = false;
 	wow_main_argv;
 	
-	fprintf(stderr, "welcome to z64compress <z64.me>\n");
+	printer = stderr;
+	for (int i = 1; i < argc; ++i)
+	{
+		if (!strcmp(argv[i], "--only-stdout"))
+		{
+			setvbuf(stdout, NULL, _IONBF, 0);
+			printer = stdout;
+		}
+	}
+	
+	fprintf(printer, "welcome to z64compress <z64.me>\n");
 	
 	if (argc <= 1)
 	{
@@ -217,8 +232,31 @@ wow_main
 	for (int i = 1; i < argc; i += 2)
 	{
 		const char *arg = argv[i];
-		const char *next = argv[i + 1];
 		
+		/* arguments that do not require additional parameters */
+
+		if(!strcmp(arg, "--only-stdout"))
+		{
+			if (Aonly_stdout)
+				die("--only-stdout arg provided more than once");
+			// handled above
+			Aonly_stdout = true;
+			i--;
+			continue;
+		}
+		else if (!strcmp(arg, "--matching"))
+		{
+			if (Amatching)
+				die("--matching arg provided more than once");
+			Amatching = true;
+			i--;
+			continue;
+		}
+		
+		/* arguments with additional parameters */
+
+		const char *next = argv[i + 1];
+
 		if (!next)
 			die("%s missing parameter", arg);
 		
@@ -234,13 +272,6 @@ wow_main
 			if (Aout)
 				die("--out arg provided more than once");
 			Aout = next;
-		}
-		else if (!strcmp(arg, "--matching"))
-		{
-			if (Amatching)
-				die("--matching arg provided more than once");
-			Amatching = true;
-			i--; // hack, this option has no arguments
 		}
 		else if (!strcmp(arg, "--cache"))
 		{
@@ -334,11 +365,11 @@ wow_main
 	
 	/* compress rom */
 	rom_compress(rom, Amb, Athreads, Amatching);
-	fprintf(stderr, "rom compressed successfully!\n");
+	fprintf(printer, "rom compressed successfully!\n");
 	
 	/* write compressed rom */
 	rom_save(rom, Aout);
-	fprintf(stderr, "compressed rom written successfully!\n");
+	fprintf(printer, "compressed rom written successfully!\n");
 	
 	/* cleanup */
 	rom_free(rom);

--- a/src/main.c
+++ b/src/main.c
@@ -189,7 +189,8 @@ static void usage(void)
 	fprintf(printer, "    --threads      optional multithreading;\n");
 	fprintf(printer, "                   exclude this argument to disable it\n");
 	fprintf(printer, "\n");
-	fprintf(printer, "    --only-stdout  reserve printer for true errors\n");
+	fprintf(printer, "    --only-stdout  reserve stderr for errors and print\n");
+	fprintf(printer, "                   everything else to stdout\n");
 	fprintf(printer, "\n");
 	fprintf(printer, "  arguments are executed as they\n");
 	fprintf(printer, "  are parsed, so order matters!\n");
@@ -209,7 +210,7 @@ wow_main
 	bool Amatching = false;
 	bool Aonly_stdout = false;
 	wow_main_argv;
-	
+
 	printer = stderr;
 	for (int i = 1; i < argc; ++i)
 	{

--- a/src/rom.c
+++ b/src/rom.c
@@ -40,6 +40,8 @@
 #define  fwrite  wow_fwrite
 #define  remove  wow_remove
 
+extern FILE* printer;
+
 #define SIZE_16MB (1024 * 1024 * 16)
 #define SIZE_4MB  (1024 * 1024 * 4)
 
@@ -534,7 +536,7 @@ static void report_progress(
 	/* caching enabled */
 	if (rom->cache)
 		fprintf(
-			stderr
+			printer
 			, "\r""updating '%s/%s' %d/%d: "
 			, rom->cache
 			, codec
@@ -544,7 +546,7 @@ static void report_progress(
 	
 	else
 		fprintf(
-			stderr
+			printer
 			, "\r""compressing file %d/%d: "
 			, v
 			, total
@@ -1050,7 +1052,7 @@ void rom_compress(struct rom *rom, int mb, int numThreads, bool matching)
 	
 	/* all files now compressed */
 	report_progress(rom, codec, PROGRESS_A_B);
-	fprintf(stderr, "success!\n");
+	fprintf(printer, "success!\n");
 	
 	/* sort by original start, ascending */
 	DMASORT(rom, sortfunc_dma_start_ascend);
@@ -1079,7 +1081,7 @@ void rom_compress(struct rom *rom, int mb, int numThreads, bool matching)
 		char *fn = dma->compname;
 		unsigned int sz;
 		unsigned int sz16;
-		fprintf(stderr, "\r""injecting file %d/%d: ", PROGRESS_A_B);
+		fprintf(printer, "\r""injecting file %d/%d: ", PROGRESS_A_B);
 		
 		if (dma->deleted)
 			continue;
@@ -1150,11 +1152,11 @@ void rom_compress(struct rom *rom, int mb, int numThreads, bool matching)
 			}
 		}
 	}
-	fprintf(stderr, "\r""injecting file %d/%d: ", dma_num, dma_num);
-	fprintf(stderr, "success!\n");
+	fprintf(printer, "\r""injecting file %d/%d: ", dma_num, dma_num);
+	fprintf(printer, "success!\n");
 	
 	fprintf(
-		stderr
+		printer
 		, "compression ratio: %.02f%%\n"
 		, (total_compressed / total_decompressed) * 100.0f
 	);
@@ -1339,7 +1341,7 @@ void rom_dma_ready(struct rom *rom, bool matching)
 		if (dma->end == dma->start)
 		{
 			fprintf(
-				stderr
+				printer
 				, "warning: dma entry %d is empty file (%08X == %08X)\n"
 				, dma->index, dma->start, dma->end
 			);
@@ -1513,7 +1515,7 @@ void rom_dma_repack(
 		
 		/* fatal error */
 		if (errstr)
-			die(errstr);
+			die("%s", errstr);
 		
 		/* repacked archive won't fit in place of original archive */
 		if (Nsz > Osz)
@@ -1525,7 +1527,7 @@ void rom_dma_repack(
 		memcpy(dst, rom->mem.mb16, Nsz);
 		
 		/* file sizes changed */
-		fprintf(stderr, "%.2f kb saved!\n", ((float)(Osz-Nsz))/1000.0f);
+		fprintf(printer, "%.2f kb saved!\n", ((float)(Osz-Nsz))/1000.0f);
 		
 		dma->end = dma->start + Nsz;
 		


### PR DESCRIPTION
If this argument is given, changes the print destination to `stdout` instead of `stderr`. True errors, such as from `die`, still go to `stderr`.
Also makes a very minor change to the Makefile so that the Makefile doesn't try to run anything if the executable is already up to date.
