### PR TITLE
Use less strict alignment for OoT Randomizer

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -221,7 +221,7 @@ wow_main
 		}
 	}
 	
-	fprintf(printer, "welcome to z64compress <z64.me>\n");
+	fprintf(printer, "welcome to z64compress 1.0.1 <z64.me>\n");
 	
 	if (argc <= 1)
 	{

--- a/src/rom.c
+++ b/src/rom.c
@@ -1279,10 +1279,10 @@ void rom_dma(struct rom *rom, unsigned int offset, int num_entries, bool matchin
 		
 		/* invalid dma conditions */
 		else if (
-			(dma->Pend & 15) /* not 16-byte aligned */
-			|| (dma->Pstart & 15)
-			|| (dma->start  & 15)
-			|| (dma->end & 15)
+			(dma->Pend & 3) /* not 4-byte aligned */
+			|| (dma->Pstart & 3)
+			|| (dma->start  & 3)
+			|| (dma->end & 3)
 			|| dma->start > dma->end
 			|| (dma->Pstart > dma->Pend && dma->Pend)
 			|| dma->Pend > rom->data_sz


### PR DESCRIPTION
This solves issue #4 without breaking anything.