### PR TITLE
Move -march -mtune flags behind a NATIVE_OPT makefile option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,23 +1,28 @@
 CC := gcc
-CFLAGS := -DNDEBUG -s -Os -flto -Wall -Wextra -march=native -mtune=native
+CFLAGS := -DNDEBUG -s -Os -flto -Wall -Wextra
 
-OBJ_DIR := o
-
-# Target platform, specify with TARGET= on the command line, linux64 is default
+# Target platform, specify with TARGET= on the command line, linux64 is default.
 # Currently supported: linux64, linux32, win32
 TARGET ?= linux64
 
 ifeq ($(TARGET),linux32)
 	TARGET_CFLAGS := -m32
 else ifeq ($(TARGET),win32)
-# If using a cross compiler, specify the compiler executable on the command line
+# If using a cross compiler, specify the compiler executable on the command line.
 # make TARGET=win32 CC=~/c/mxe/usr/bin/i686-w64-mingw32.static-gcc
 	TARGET_LIBS := -mconsole -municode
 else ifneq ($(TARGET),linux64)
 	$(error Supported targets: linux64, linux32, win32)
 endif
 
-OBJ_DIR := $(OBJ_DIR)/$(TARGET)
+# Whether to use native optimizations, specify with NATIVE_OPT=0/1 on the command line, default is 0.
+# This is not supported by all compilers which is particularly an issue on Mac, and may inhibit tests.
+NATIVE_OPT ?= 0
+ifeq ($(NATIVE_OPT),1)
+	TARGET_CFLAGS += -march=native -mtune=native
+endif
+
+OBJ_DIR := o/$(TARGET)
 
 $(OBJ_DIR)/src/enc/%.o: CFLAGS := -DNDEBUG -s -Ofast -flto -Wall
 


### PR DESCRIPTION
The `-march` and `-mtune` compiler flags are not supported with some architectures. I've moved these flags behind a `NATIVE_OPT` make option, to keep them available for those who can and want to use them. To use them, build with `make NATIVE_OPT=1`.
Addresses #7 
